### PR TITLE
fixed missing coords in CONTEXT parser

### DIFF
--- a/R/c14_date_list_basic.R
+++ b/R/c14_date_list_basic.R
@@ -40,6 +40,7 @@ as.c14_date_list <- function(x, ...) {
         `class<-`(c("c14_date_list", class(.))) %>%
         c14bazAAR::order_variables() %>%
         c14bazAAR::enforce_types() %>%
+        c14bazAAR::clean() %>%
         return()
     } else {
       stop(

--- a/R/c14_date_list_clean.R
+++ b/R/c14_date_list_clean.R
@@ -36,7 +36,7 @@ clean.c14_date_list <- function(x) {
 
   # add class again -- gets lost in in mutate_if :-(
   x <- x %>%
-    as.c14_date_list()
+    `class<-`(c("c14_date_list", class(.)))
 
   return(x)
 }

--- a/R/context.R
+++ b/R/context.R
@@ -45,8 +45,8 @@ get_CONTEXT <- function(db_url = get_db_url("CONTEXT")) {
       calBC68 = "_",
       calBC95 = "_",
       REGION = readr::col_character(),
-      LATITUDE = readr::col_character(),
-      LONGITUDE = readr::col_character(),
+      LATITUDE = readr::col_double(),
+      LONGITUDE = readr::col_double(),
       INCONGR = "_",
       NOTICE = readr::col_character(),
       REFERENCE = readr::col_character(),
@@ -75,7 +75,9 @@ get_CONTEXT <- function(db_url = get_db_url("CONTEXT")) {
       shortref = .data[["REFERENCE"]],
       comment = .data[["NOTICE"]]
     ) %>% dplyr::mutate(
-      sourcedb = "CONTEXT"
+      sourcedb = "CONTEXT",
+      lat = replace(lat, lat==0, NA),
+      lon = replace(lon, lon==0, NA)
     ) %>%
     as.c14_date_list()
 

--- a/R/context.R
+++ b/R/context.R
@@ -25,7 +25,6 @@ get_CONTEXT <- function(db_url = get_db_url("CONTEXT")) {
     delim = ";",
     trim_ws = TRUE,
     na = c("-", "--", "---", "", "NA", "n.d.", "?"),
-    locale = readr::locale(decimal_mark = ","),
     col_types = readr::cols(
       LABNR = readr::col_character(),
       GR = "_",
@@ -45,8 +44,8 @@ get_CONTEXT <- function(db_url = get_db_url("CONTEXT")) {
       calBC68 = "_",
       calBC95 = "_",
       REGION = readr::col_character(),
-      LATITUDE = readr::col_double(),
-      LONGITUDE = readr::col_double(),
+      LATITUDE = readr::col_character(),
+      LONGITUDE = readr::col_character(),
       INCONGR = "_",
       NOTICE = readr::col_character(),
       REFERENCE = readr::col_character(),
@@ -76,8 +75,8 @@ get_CONTEXT <- function(db_url = get_db_url("CONTEXT")) {
       comment = .data[["NOTICE"]]
     ) %>% dplyr::mutate(
       sourcedb = "CONTEXT",
-      lat = replace(lat, lat==0, NA),
-      lon = replace(lon, lon==0, NA)
+      lat = gsub(",", ".", lat),
+      lon = gsub(",", ".", lon)
     ) %>%
     as.c14_date_list()
 


### PR DESCRIPTION
`readr::col_character` introduced a bug in which the coordinates get droped. Please compare against `master`. Removing 0's, which are already in the dataset, results in a warning and subsequent note during check.