### PR TITLE
catching download errors in get_all_dates

### DIFF
--- a/R/get_all_dates.R
+++ b/R/get_all_dates.R
@@ -43,9 +43,17 @@ get_all_dates <- function() {
   date_lists <- list()
   for (i in 1:length(parser_functions)) {
     # call parser function
-    date_lists[[i]] <- parser_functions[[i]]()
+    date_lists[[i]] <- tryCatch(parser_functions[[i]](),error=function(e) e)
     # increment progress bar
     utils::setTxtProgressBar(pb, 99 * i/length(parser_functions))
+  }
+
+  error_ind <- sapply(date_lists,function(x) !('c14_date_list' %in% class(x)))
+  errors <- date_lists[error_ind]
+  date_lists <- date_lists[!error_ind]
+
+  if(any(error_ind)) {
+    warning(paste("There were errors:\n\n",paste(sapply(errors,function(x) x$message), collapse = "\n"),"\n\nNot all data might have been downloaded accurately!",sep=""))
   }
 
   # fuse radiocarbon lists

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <img align="right" src="khajiit.jpg" width = 350>
 
-c14bazAAR is a R package to query different openly accessible radiocarbon date databases. It allows basic data cleaning, calibration and merging. It serves as back end of the [neolithicRC WebApp](https://github.com/nevrome/neolithicR). If you're not familiar with R the [WebApp](http://www.neolithicRC.de) might be better suited for your needs.
+c14bazAAR is a R package to query different openly accessible radiocarbon date databases. It allows basic data cleaning, calibration and merging. It serves as back end of our [neolithicRC WebApp](https://github.com/nevrome/neolithicR). If you're not familiar with R the [WebApp](http://www.neolithicRC.de) or other tools (such as [GoGet](http://www.ibercrono.org/goget/index.php)) to search for radiocarbon dates might be better suited for your needs. 
 
 - [Installation](#installation)
 - [How to use](#how-to-use)

--- a/tests/testthat/test_get_dates.R
+++ b/tests/testthat/test_get_dates.R
@@ -22,24 +22,6 @@ test_that("get_all_parser_functions gives back a list of functions", {
   )
 })
 
-#### two random parser function - to reduce test time ####
-
-date_lists <- list()
-date_lists[[1]] <- sample(parser_functions, 1)[[1]]()
-date_lists[[2]] <- sample(parser_functions, 1)[[1]]()
-
-test_that("two random parsers give back a c14_date_list", {
-  expect_true(
-    all(sapply(date_lists, c14bazAAR::is.c14_date_list))
-  )
-})
-
-test_that("two random parsers give back a c14_date_list with more than one entry", {
-  expect_true(
-    all(sapply(date_lists, nrow) > 1)
-  )
-})
-
 #### get_all_dates ####
 
 all_dates <- c14bazAAR::get_all_dates()
@@ -50,10 +32,9 @@ test_that("get_all_dates gives back a c14_date_list", {
   )
 })
 
-test_that("get_all_dates gives back a c14_date_list with more entries
-          compared with calling two parsers", {
+test_that("get_all_dates gives back a c14_date_list with more than one entry", {
   expect_gt(
-    nrow(all_dates), sum(sapply(date_lists, nrow))
+    nrow(all_dates), 1
   )
 })
 


### PR DESCRIPTION
Errors are catched and printed later, return contains only those datasets that did not throw an error. Please check!